### PR TITLE
Fix macro redefinition

### DIFF
--- a/libIP2Location/IP2Location.c
+++ b/libIP2Location/IP2Location.c
@@ -266,7 +266,7 @@ IP2LocationRecord *IP2Location_get_longitude(IP2Location *loc, char *ip)
 // Description: Get domain name
 IP2LocationRecord *IP2Location_get_domain(IP2Location *loc, char *ip)
 {
-    return IP2Location_get_record(loc, ip, DOMAIN);
+    return IP2Location_get_record(loc, ip, DOMAIN_);
 }
 
 // Description: Get ZIP code
@@ -445,7 +445,7 @@ static IP2LocationRecord *IP2Location_read_record(IP2Location *loc, uint32_t row
         record->longitude = 0.0;
     }
 
-    if ((mode & DOMAIN) && (DOMAIN_POSITION[dbtype] != 0))
+    if ((mode & DOMAIN_) && (DOMAIN_POSITION[dbtype] != 0))
     {
         record->domain = IP2Location_readStr(handle, IP2Location_read32(handle, rowaddr + 4 * (DOMAIN_POSITION[dbtype]-1)));
     }

--- a/libIP2Location/IP2Location.h
+++ b/libIP2Location/IP2Location.h
@@ -85,7 +85,7 @@ extern "C" {
 #define  ISP                    0x00010
 #define  LATITUDE               0x00020
 #define  LONGITUDE              0x00040
-#define  DOMAIN                 0x00080
+#define  DOMAIN_                0x00080 // DOMAIN is a math.h macro
 #define  ZIPCODE                0x00100
 #define  TIMEZONE               0x00200
 #define  NETSPEED               0x00400
@@ -99,7 +99,7 @@ extern "C" {
 #define  ELEVATION              0x40000
 #define  USAGETYPE              0x80000
 
-#define  ALL          COUNTRYSHORT | COUNTRYLONG | REGION | CITY | ISP | LATITUDE | LONGITUDE | DOMAIN | ZIPCODE | TIMEZONE | NETSPEED | IDDCODE | AREACODE | WEATHERSTATIONCODE | WEATHERSTATIONNAME | MCC | MNC | MOBILEBRAND | ELEVATION | USAGETYPE
+#define  ALL          COUNTRYSHORT | COUNTRYLONG | REGION | CITY | ISP | LATITUDE | LONGITUDE | DOMAIN_ | ZIPCODE | TIMEZONE | NETSPEED | IDDCODE | AREACODE | WEATHERSTATIONCODE | WEATHERSTATIONNAME | MCC | MNC | MOBILEBRAND | ELEVATION | USAGETYPE
 
 #define  DEFAULT	     0x0001
 #define  NO_EMPTY_STRING 0x0002


### PR DESCRIPTION
DOMAIN is a math.h macro to provide SystemV support, meaning that depending on your compiler (and compiler flags) you can end up with a macro redefinition. This just changes the libip2location macro to DOMAIN_ to avoid these conflicts.