### PR TITLE
explicitly check whether ipv6databasecount > 0

### DIFF
--- a/libIP2Location/IP2Location.c
+++ b/libIP2Location/IP2Location.c
@@ -579,6 +579,11 @@ static IP2LocationRecord *IP2Location_get_ipv6_record(IP2Location *loc, char *ip
 
     ipno = parsed_ipv.ipv6;
 
+    if (!high)
+    {
+        return NULL;
+    }
+
     if (ipv6indexbaseaddr > 0)
     {
         // use the index table


### PR DESCRIPTION
In some databases ipv6databasecount == 0, but ipv6indexbaseaddr == 1. 
Without this extra check, the code reads invalid values for low/high and performs binary search between them, ultimately leading to seg fault.

Pasting the gdb dump of *loc on my database -
```
(gdb) p *loc
$21 = {filehandle = 0x555555d39740, databasetype = 8 '\b', databasecolumn = 8 '\b', databaseday = 31 '\037', databasemonth = 8 '\b', databaseyear = 17 '\021', databasecount = 12548626, databaseaddr = 524353, ipversion = 0,
  ipv4databasecount = 12548626, ipv4databaseaddr = 524353, ipv6databasecount = 0, ipv6databaseaddr = 1, ipv4indexbaseaddr = 65, ipv6indexbaseaddr = 1}
```