### PR TITLE
update version to 8.0.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.59)
-AC_INIT([IP2Loc], [8.0.4], [support@ip2location.com])
-AM_INIT_AUTOMAKE([IP2Loc], [8.0.4])
+AC_INIT([IP2Loc], [8.0.9], [support@ip2location.com])
+AM_INIT_AUTOMAKE([IP2Loc], [8.0.9])
 
 #AC_PREFIX_DEFAULT(/usr/)
 AM_CONFIG_HEADER([config.h])

--- a/contrib/IP2Location.spec
+++ b/contrib/IP2Location.spec
@@ -1,4 +1,4 @@
-%define	version 8.0.4
+%define	version 8.0.9
 
 Name:		IP2Location
 Summary:	C library for mapping IP address to geolocation information


### PR DESCRIPTION
RPM can't be created because release 8.0.8 still contains version 8.0.4 in included spec file.
This PR updates version to 8.0.9, so if afterwards 8.0.9 is released, everything works well in creating RPM (tested on EL8).

Don't forget to sync version in the future