### PR TITLE
Fix Shared-memory name

### DIFF
--- a/libIP2Location/IP2Location.h
+++ b/libIP2Location/IP2Location.h
@@ -95,7 +95,7 @@ extern "C" {
 #define INVALID_IP_ADDRESS "INVALID IP ADDRESS"
 #define IPV6_ADDRESS_MISSING_IN_IPV4_BIN "IPV6 ADDRESS MISSING IN IPV4 BIN"
 #define NOT_SUPPORTED "This parameter is unavailable for selected data file. Please upgrade the data file."
-#define IP2LOCATION_SHM "/IP2location_Shm"
+#define IP2LOCATION_SHM "IP2location_Shm"
 #define MAP_ADDR 4194500608
 
 enum IP2Location_lookup_mode {


### PR DESCRIPTION
Running an IP2Location program under Windows, shows a strangely named:
```
\Sessions\1\BaseNamedObjects\/IP2location_Shm
```

This PR fixes this to produce a:
```
\Sessions\1\BaseNamedObjects\IP2location_Shm_1234
```

instead. The process-id (`1234`) is now part of the name. Similar to how it's done on non-Windows.

Ref: Issue https://github.com/chrislim2888/IP2Location-C-Library/issues/44 