### PR TITLE
Fix typo and add portability of fseek()

### DIFF
--- a/libIP2Location/IP2Location.c
+++ b/libIP2Location/IP2Location.c
@@ -1056,7 +1056,7 @@ int32_t IP2Location_set_shared_memory(FILE *file)
 // Load BIN file into memory
 int32_t IP2Location_load_database_into_memory(FILE *file, void *memory, int64_t size)
 {
-	fseek(file, SEEK_SET, 0);
+	fseek(file, 0, SEEK_SET);
 	
 	if (fread(memory, size, 1, file) != 1) {
 		return -1;
@@ -1149,7 +1149,7 @@ uint32_t IP2Location_read32(FILE *handle, uint32_t position)
 	
 	// Read from file
 	if (lookup_mode == IP2LOCATION_FILE_IO && handle != NULL) {
-		fseek(handle, position - 1, 0);
+		fseek(handle, position - 1, SEEK_SET);
 		temp = fread(&byte1, 1, 1, handle);
 
 		if (temp == 0) {
@@ -1190,7 +1190,7 @@ uint8_t IP2Location_read8(FILE *handle, uint32_t position)
 	size_t temp;
 
 	if (lookup_mode == IP2LOCATION_FILE_IO && handle != NULL) {
-		fseek(handle, position - 1, 0);
+		fseek(handle, position - 1, SEEK_SET);
 		temp = fread(&ret, 1, 1, handle);
 		
 		if (temp == 0) {


### PR DESCRIPTION
From latest iso c draft n2596.pdf:
int fseek(FILE *stream, long int offset, int whence);
For whence, SEEK_SET macro is implemented as 0 in many OS, but just defined as "integer constant expressions with distinct values" in iso.