### PR TITLE
Use anonymous unions for aliased IP2LocationRecord members

### DIFF
--- a/libIP2Location/IP2Location.c
+++ b/libIP2Location/IP2Location.c
@@ -447,8 +447,6 @@ static IP2LocationRecord *IP2Location_bad_record(const char *message)
 	record->region = strdup(message);
 	record->city = strdup(message);
 	record->isp = strdup(message);
-	record->latitude = 0;
-	record->longitude = 0;
 	record->domain = strdup(message);
 	record->zipcode = strdup(message);
 	record->timezone = strdup(message);
@@ -460,19 +458,11 @@ static IP2LocationRecord *IP2Location_bad_record(const char *message)
 	record->mcc = strdup(message);
 	record->mnc = strdup(message);
 	record->mobilebrand = strdup(message);
-	record->elevation = 0;
 	record->usagetype = strdup(message);
 
-	// Create alias for the new variables
-	record->zip_code = record->zipcode;
-	record->time_zone = record->timezone;
-	record->net_speed = record->netspeed;
-	record->idd_code = record->iddcode;
-	record->area_code = record->areacode;
-	record->weather_station_code = record->weatherstationcode;
-	record->weather_station_name = record->weatherstationname;
-	record->mobile_brand = record->mobilebrand;
-	record->usage_type = record->usagetype;
+	record->latitude = 0;
+	record->longitude = 0;
+	record->elevation = 0;
 
 	record->address_type = strdup(message);
 	record->category = strdup(message);
@@ -727,17 +717,6 @@ static IP2LocationRecord *IP2Location_read_record(IP2Location *handler, uint8_t*
 			record->as = strdup(NOT_SUPPORTED);
 		}
 	}
-
-	// Create alias for the new variables
-	record->zip_code = record->zipcode;
-	record->time_zone = record->timezone;
-	record->net_speed = record->netspeed;
-	record->idd_code = record->iddcode;
-	record->area_code = record->areacode;
-	record->weather_station_code = record->weatherstationcode;
-	record->weather_station_name = record->weatherstationname;
-	record->mobile_brand = record->mobilebrand;
-	record->usage_type = record->usagetype;
 
 	return record;
 }

--- a/libIP2Location/IP2Location.h
+++ b/libIP2Location/IP2Location.h
@@ -107,7 +107,7 @@ extern "C" {
 enum IP2Location_lookup_mode {
 	IP2LOCATION_FILE_IO,
 	IP2LOCATION_CACHE_MEMORY,
-	IP2LOCATION_SHARED_MEMORY
+	IP2LOCATION_SHARED_MEMORY,
 };
 
 typedef struct {
@@ -119,6 +119,7 @@ typedef struct {
 	uint8_t database_year;
 	uint8_t product_code;
 	uint8_t license_code;
+	uint8_t dummy; /* 32-bit alignment */
 	uint32_t database_count;
 	uint32_t database_address;
 	uint32_t ip_version;
@@ -138,32 +139,49 @@ typedef struct {
 	char *city;
 	char *isp;
 	char *domain;
-	char *zipcode;
-	char *timezone;
-	char *netspeed;
-	char *iddcode;
-	char *areacode;
-	char *weatherstationcode;
-	char *weatherstationname;
+	union {
+		char *zipcode;
+		char *zip_code;
+	};
+	union {
+		char *timezone;
+		char *time_zone;
+	};
+	union {
+		char *netspeed;
+		char *net_speed;
+	};
+	union {
+		char *iddcode;
+		char *idd_code;
+	};
+	union {
+		char *areacode;
+		char *area_code;
+	};
+	union {
+		char *weatherstationcode;
+		char *weather_station_code;
+	};
+	union {
+		char *weatherstationname;
+		char *weather_station_name;
+	};
 	char *mcc;
 	char *mnc;
-	char *mobilebrand;
-	char *usagetype;
+	union {
+		char *mobilebrand;
+		char *mobile_brand;
+	};
+	union {
+		char *usagetype;
+		char *usage_type;
+	};
 
 	float latitude;
 	float longitude;
 	float elevation;
 
-	/* Variables changed since 8.1.0 */
-	char *zip_code;
-	char *time_zone;
-	char *net_speed;
-	char *idd_code;
-	char *area_code;
-	char *weather_station_code;
-	char *weather_station_name;
-	char *mobile_brand;
-	char *usage_type;
 	char *address_type;
 	char *category;
 	char *district;


### PR DESCRIPTION
Using anonymous unions gives a smaller memory footprint and eliminate copying.