### PR TITLE
Link -lrt only on Linux/FreeBSD to fix macOS build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 bin_PROGRAMS=ip2location
 
 ip2location_SOURCES=ip2location.c libIP2Location/IP2Location.c
-ip2location_LDADD=-lrt
 ip2location_CFLAGS=-IlibIP2Location -Wall
 
 dist_man_MANS=ip2location.1

--- a/README
+++ b/README
@@ -48,7 +48,6 @@ sudo apt install ip2location
 
 ### MacOS
     autoreconf -i -v --force
-    export CFLAGS=-I/usr/include/malloc
     ./configure
     make
     make install

--- a/configure.ac
+++ b/configure.ac
@@ -14,12 +14,10 @@ case "$host" in
   # FreeBSD forgot to  install magic.h in a sane location. Bug or Feature?
   CPPFLAGS="$CPPFLAGS -I/usr/include -I/usr/src/contrib/file/"
   LDFLAGS="$LDFLAGS -L/usr/lib -R/usr/lib"
-  CFLAGS="$CFLAGS -lrt"
   ;;
 *-*-linux*)
   CPPFLAGS="$CPPFLAGS -D _GNU_SOURCE -I/usr/include -Wno-unused-result"
   LDFLAGS="$LDFLAGS"
-  CFLAGS="$CFLAGS -lrt"
   ;;
 *-*-darwin*)
   CPPFLAGS="$CPPFLAGS -I/opt/include"
@@ -35,6 +33,11 @@ AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
+
+# Checks for libraries.
+# shm_open() lives in librt on Linux (glibc < 2.34) but in libc on the BSDs,
+# macOS, and newer glibc. Probe for it instead of hardcoding -lrt per host.
+AC_SEARCH_LIBS([shm_open], [rt])
 
 AC_CHECK_HEADERS([netinet/in.h stdlib.h string.h unistd.h])
 

--- a/debian/README
+++ b/debian/README
@@ -24,7 +24,6 @@ perl ip-country.pl
 MacOS
 
 autoreconf -i -v --force
-export CFLAGS=-I/usr/include/malloc 
 ./configure
 make
 cd data

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -55,7 +55,6 @@ sudo apt install ip2location
 
 ```
     autoreconf -i -v --force
-    export CFLAGS=-I/usr/include/malloc
     ./configure
     make
     make install


### PR DESCRIPTION
Per https://github.com/Homebrew/homebrew-core/pull/287943, hardcoding -lrt in ip2location_LDADD broke the macOS build.

Move it to a host-conditional RT_LIBS substitution (empty on Darwin) instead of placing the linker flag in CFLAGS.